### PR TITLE
Add `hideCompleted` filter to items page, update UI and tests

### DIFF
--- a/src/main/java/com/todoapp/web/ViewController.java
+++ b/src/main/java/com/todoapp/web/ViewController.java
@@ -4,12 +4,14 @@ import com.todoapp.domain.TodoItem;
 import com.todoapp.domain.TodoList;
 import com.todoapp.service.TodoItemService;
 import com.todoapp.service.TodoListService;
-import java.util.List;
-import java.util.UUID;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Controller for server-rendered HTML views.
@@ -18,76 +20,86 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Controller
 public class ViewController {
 
-  private final TodoListService listService;
-  private final TodoItemService itemService;
+    private final TodoListService listService;
+    private final TodoItemService itemService;
 
-  public ViewController(TodoListService listService, TodoItemService itemService) {
-    this.listService = listService;
-    this.itemService = itemService;
-  }
-
-  /**
-   * Displays the main lists page.
-   *
-   * @param model the Spring MVC model
-   * @return the lists template name
-   */
-  @GetMapping("/lists")
-  public String listsPage(Model model) {
-    try {
-      List<TodoList> lists = listService.getAllLists();
-      model.addAttribute("lists", lists);
-      model.addAttribute("hasLists", !lists.isEmpty());
-    } catch (Exception e) {
-      // Handle service errors gracefully - still show the page
-      model.addAttribute("lists", List.of());
-      model.addAttribute("hasLists", false);
-      model.addAttribute("error", "Unable to load lists. Please try again.");
+    public ViewController(TodoListService listService, TodoItemService itemService) {
+        this.listService = listService;
+        this.itemService = itemService;
     }
-    return "lists";
-  }
 
-  /**
-   * Displays the items page for a specific list.
-   *
-   * @param listId the list identifier
-   * @param model the Spring MVC model
-   * @return the items template name
-   */
-  @GetMapping("/lists/{listId}/items")
-  public String itemsPage(@PathVariable String listId, Model model) {
-    try {
-      UUID uuid = UUID.fromString(listId);
-      
-      // Get the list details
-      TodoList todoList = listService.getListById(uuid)
-          .orElseThrow(() -> new IllegalArgumentException("List not found"));
-      
-      // Get items for this list
-      List<TodoItem> items = itemService.getItemsByList(uuid);
-      
-      model.addAttribute("list", todoList);
-      model.addAttribute("items", items);
-      model.addAttribute("hasItems", !items.isEmpty());
-      model.addAttribute("listId", listId);
-      
-    } catch (IllegalArgumentException e) {
-      // Handle invalid UUID or list not found
-      model.addAttribute("list", null);
-      model.addAttribute("items", List.of());
-      model.addAttribute("hasItems", false);
-      model.addAttribute("listId", listId);
-      model.addAttribute("error", "List not found or invalid ID.");
-      
-    } catch (Exception e) {
-      // Handle other service errors gracefully
-      model.addAttribute("list", null);
-      model.addAttribute("items", List.of());
-      model.addAttribute("hasItems", false);
-      model.addAttribute("listId", listId);
-      model.addAttribute("error", "Unable to load items. Please try again.");
+    /**
+     * Displays the main lists page.
+     *
+     * @param model the Spring MVC model
+     * @return the lists template name
+     */
+    @GetMapping("/lists")
+    public String listsPage(Model model) {
+        try {
+            List<TodoList> lists = listService.getAllLists();
+            model.addAttribute("lists", lists);
+            model.addAttribute("hasLists", !lists.isEmpty());
+        } catch (Exception e) {
+            // Handle service errors gracefully - still show the page
+            model.addAttribute("lists", List.of());
+            model.addAttribute("hasLists", false);
+            model.addAttribute("error", "Unable to load lists. Please try again.");
+        }
+        return "lists";
     }
-    
-    return "items";
-  }
+
+    /**
+     * Displays the items page for a specific list.
+     *
+     * @param listId        the list identifier
+     * @param hideCompleted optional parameter to hide completed items
+     * @param model         the Spring MVC model
+     * @return the items template name
+     */
+    @GetMapping("/lists/{listId}/items")
+    public String itemsPage(@PathVariable String listId,
+                            @RequestParam(required = false) Boolean hideCompleted,
+                            Model model
+    ) {
+        try {
+            // Get the list details
+            UUID listUUID = UUID.fromString(listId);
+            TodoList todoList = listService.getListById(listUUID)
+                    .orElseThrow(() -> new IllegalArgumentException("List not found"));
+
+            List<TodoItem> items = getTodoItems(listUUID, hideCompleted);
+
+            model.addAttribute("list", todoList);
+            model.addAttribute("items", items);
+            model.addAttribute("hasItems", !items.isEmpty());
+            model.addAttribute("listId", listId);
+            model.addAttribute("hideCompleted", hideCompleted);
+
+        } catch (IllegalArgumentException e) {
+            // Handle invalid UUID or list not found
+            handleException(model, listId, hideCompleted, "List not found or invalid ID.");
+        } catch (Exception e) {
+            // Handle other service errors gracefully
+            handleException(model, listId, hideCompleted, "Unable to load items. Please try again.");
+        }
+        return "items";
+    }
+
+    private static void handleException(Model model, String listId, Boolean hideCompleted, String attributeValue) {
+        model.addAttribute("list", null);
+        model.addAttribute("items", List.of());
+        model.addAttribute("hasItems", false);
+        model.addAttribute("listId", listId);
+        model.addAttribute("hideCompleted", hideCompleted);
+        model.addAttribute("error", attributeValue);
+    }
+
+    List<TodoItem> getTodoItems(UUID listUUID, Boolean hideCompleted) {
+        if (Boolean.TRUE.equals(hideCompleted)) {
+            return itemService.getItemsByListAndStatus(listUUID, false);
+        } else {
+            return itemService.getItemsByList(listUUID);
+        }
+    }
 }

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -278,6 +278,16 @@
             </div>
             <button type="submit">Add Item</button>
         </form>
+
+        <!-- Toggle completed items visibility -->
+        <div class="filter-controls" th:if="${list}" style="margin-bottom: 20px; text-align: center;">
+            <a th:href="@{/lists/{id}/items(id=${list.id}, hideCompleted=${hideCompleted != null and hideCompleted ? 'false' : 'true'})}" 
+               class="btn-filter"
+               style="background: #6c757d; color: white; padding: 8px 16px; border-radius: 4px; text-decoration: none; font-size: 14px; font-weight: 600;">
+                <span th:if="${hideCompleted != null and hideCompleted}">Show Completed</span>
+                <span th:unless="${hideCompleted != null and hideCompleted}">Hide Completed</span>
+            </a>
+        </div>
         
         <!-- Items container -->
         <div id="items-container">

--- a/src/test/java/com/todoapp/unit/web/ItemsControllerTest.java
+++ b/src/test/java/com/todoapp/unit/web/ItemsControllerTest.java
@@ -80,7 +80,7 @@ class ItemsControllerTest {
   }
 
   @Test
-  void getItemsByListAndStatus_shouldFilterByCompletedStatus() throws Exception {
+  void getItemsByListAndStatus_shouldFilterByCompletedStatusTrue() throws Exception {
     // Given
     UUID listId = UUID.randomUUID();
     TodoItem completedItem = new TodoItem(UUID.randomUUID(), listId, "Completed task", true, Instant.now());
@@ -96,6 +96,27 @@ class ItemsControllerTest {
         .andExpect(jsonPath("$.length()").value(1))
         .andExpect(jsonPath("$[0].text").value("Completed task"))
         .andExpect(jsonPath("$[0].completed").value(true));
+
+    verify(itemService).getItemsByListAndStatus(listId, true);
+  }
+
+@Test
+  void getItemsByListAndStatus_shouldFilterByCompletedStatusFalse() throws Exception {
+    // Given
+    UUID listId = UUID.randomUUID();
+    TodoItem notCompletedItem = new TodoItem(UUID.randomUUID(), listId, "Not Completed task", false, Instant.now());
+    when(itemService.getItemsByListAndStatus(listId, true)).thenReturn(List.of(notCompletedItem));
+
+    // When & Then
+    mockMvc.perform(get("/api/lists/{listId}/items", listId)
+            .param("completed", "true")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].text").value("Not Completed task"))
+        .andExpect(jsonPath("$[0].completed").value(false));
 
     verify(itemService).getItemsByListAndStatus(listId, true);
   }

--- a/src/test/java/com/todoapp/web/ViewControllerTest.java
+++ b/src/test/java/com/todoapp/web/ViewControllerTest.java
@@ -1,0 +1,235 @@
+package com.todoapp.web;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.todoapp.domain.TodoItem;
+import com.todoapp.domain.TodoList;
+import com.todoapp.service.TodoItemService;
+import com.todoapp.service.TodoListService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+@ExtendWith(MockitoExtension.class)
+class ViewControllerTest {
+
+    @Mock
+    private TodoListService listService;
+
+    @Mock
+    private TodoItemService itemService;
+
+    @Mock
+    private Model model;
+
+    private ViewController controller;
+    private UUID testListId;
+    private TodoList testList;
+    private List<TodoItem> testItems;
+
+    @BeforeEach
+    void setUp() {
+        controller = new ViewController(listService, itemService);
+        testListId = UUID.randomUUID();
+        testList = new TodoList(testListId, "Test List", Instant.now());
+        
+        // Create test items
+        TodoItem item1 = new TodoItem(UUID.randomUUID(), testListId, "Item 1", false, Instant.now());
+        TodoItem item2 = new TodoItem(UUID.randomUUID(), testListId, "Item 2", true, Instant.now());
+        
+        testItems = List.of(item1, item2);
+    }
+
+    @Test
+    void itemsPage_withValidListId_shouldReturnItemsViewWithCorrectAttributes() {
+        // Given
+        String listIdStr = testListId.toString();
+        when(listService.getListById(testListId)).thenReturn(Optional.of(testList));
+        when(itemService.getItemsByList(testListId)).thenReturn(testItems);
+
+        // When
+        String result = controller.itemsPage(listIdStr, null, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", testList);
+        verify(model).addAttribute("items", testItems);
+        verify(model).addAttribute("hasItems", true);
+        verify(model).addAttribute("listId", listIdStr);
+        verify(model).addAttribute("hideCompleted", null);
+        verify(model, never()).addAttribute(eq("error"), any());
+    }
+
+    @Test
+    void itemsPage_withValidListIdAndHideCompletedTrue_shouldReturnFilteredItems() {
+        // Given
+        String listIdStr = testListId.toString();
+        List<TodoItem> incompleteItems = List.of(testItems.get(0)); // Only incomplete item
+        when(listService.getListById(testListId)).thenReturn(Optional.of(testList));
+        when(itemService.getItemsByListAndStatus(testListId, false)).thenReturn(incompleteItems);
+
+        // When
+        String result = controller.itemsPage(listIdStr, true, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", testList);
+        verify(model).addAttribute("items", incompleteItems);
+        verify(model).addAttribute("hasItems", true);
+        verify(model).addAttribute("listId", listIdStr);
+        verify(model).addAttribute("hideCompleted", true);
+        verify(model, never()).addAttribute(eq("error"), any());
+    }
+
+    @Test
+    void itemsPage_withValidListIdAndHideCompletedFalse_shouldReturnAllItems() {
+        // Given
+        String listIdStr = testListId.toString();
+        when(listService.getListById(testListId)).thenReturn(Optional.of(testList));
+        when(itemService.getItemsByList(testListId)).thenReturn(testItems);
+
+        // When
+        String result = controller.itemsPage(listIdStr, false, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", testList);
+        verify(model).addAttribute("items", testItems);
+        verify(model).addAttribute("hasItems", true);
+        verify(model).addAttribute("listId", listIdStr);
+        verify(model).addAttribute("hideCompleted", false);
+        verify(model, never()).addAttribute(eq("error"), any());
+    }
+
+    @Test
+    void itemsPage_withEmptyItemsList_shouldSetHasItemsFalse() {
+        // Given
+        String listIdStr = testListId.toString();
+        List<TodoItem> emptyItems = List.of();
+        when(listService.getListById(testListId)).thenReturn(Optional.of(testList));
+        when(itemService.getItemsByList(testListId)).thenReturn(emptyItems);
+
+        // When
+        String result = controller.itemsPage(listIdStr, null, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", testList);
+        verify(model).addAttribute("items", emptyItems);
+        verify(model).addAttribute("hasItems", false);
+        verify(model).addAttribute("listId", listIdStr);
+        verify(model).addAttribute("hideCompleted", null);
+        verify(model, never()).addAttribute(eq("error"), any());
+    }
+
+    @Test
+    void itemsPage_withInvalidUuid_shouldHandleExceptionGracefully() {
+        // Given
+        String invalidListId = "invalid-uuid";
+
+        // When
+        String result = controller.itemsPage(invalidListId, null, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", null);
+        verify(model).addAttribute("items", List.of());
+        verify(model).addAttribute("hasItems", false);
+        verify(model).addAttribute("listId", invalidListId);
+        verify(model).addAttribute("hideCompleted", null);
+        verify(model).addAttribute("error", "List not found or invalid ID.");
+        verify(listService, never()).getListById(any());
+    }
+
+    @Test
+    void itemsPage_withNonExistentList_shouldHandleExceptionGracefully() {
+        // Given
+        String listIdStr = testListId.toString();
+        when(listService.getListById(testListId)).thenReturn(Optional.empty());
+
+        // When
+        String result = controller.itemsPage(listIdStr, null, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", null);
+        verify(model).addAttribute("items", List.of());
+        verify(model).addAttribute("hasItems", false);
+        verify(model).addAttribute("listId", listIdStr);
+        verify(model).addAttribute("hideCompleted", null);
+        verify(model).addAttribute("error", "List not found or invalid ID.");
+        verify(itemService, never()).getItemsByList(any());
+    }
+
+    @Test
+    void itemsPage_withServiceException_shouldHandleExceptionGracefully() {
+        // Given
+        String listIdStr = testListId.toString();
+        when(listService.getListById(testListId)).thenThrow(new RuntimeException("Database error"));
+
+        // When
+        String result = controller.itemsPage(listIdStr, true, model);
+
+        // Then
+        assertThat(result).isEqualTo("items");
+        verify(model).addAttribute("list", null);
+        verify(model).addAttribute("items", List.of());
+        verify(model).addAttribute("hasItems", false);
+        verify(model).addAttribute("listId", listIdStr);
+        verify(model).addAttribute("hideCompleted", true);
+        verify(model).addAttribute("error", "Unable to load items. Please try again.");
+        verify(itemService, never()).getItemsByList(any());
+    }
+
+    @Test
+    void getTodoItems_withHideCompletedTrue_shouldReturnIncompleteItems() {
+        // Given
+        List<TodoItem> incompleteItems = List.of(testItems.get(0));
+        when(itemService.getItemsByListAndStatus(testListId, false)).thenReturn(incompleteItems);
+
+        // When
+        List<TodoItem> result = controller.getTodoItems(testListId, true);
+
+        // Then
+        assertThat(result).isEqualTo(incompleteItems);
+        verify(itemService).getItemsByListAndStatus(testListId, false);
+        verify(itemService, never()).getItemsByList(any());
+    }
+
+    @Test
+    void getTodoItems_withHideCompletedFalse_shouldReturnAllItems() {
+        // Given
+        when(itemService.getItemsByList(testListId)).thenReturn(testItems);
+
+        // When
+        List<TodoItem> result = controller.getTodoItems(testListId, false);
+
+        // Then
+        assertThat(result).isEqualTo(testItems);
+        verify(itemService).getItemsByList(testListId);
+        verify(itemService, never()).getItemsByListAndStatus(any(), anyBoolean());
+    }
+
+    @Test
+    void getTodoItems_withHideCompletedNull_shouldReturnAllItems() {
+        // Given
+        when(itemService.getItemsByList(testListId)).thenReturn(testItems);
+
+        // When
+        List<TodoItem> result = controller.getTodoItems(testListId, null);
+
+        // Then
+        assertThat(result).isEqualTo(testItems);
+        verify(itemService).getItemsByList(testListId);
+        verify(itemService, never()).getItemsByListAndStatus(any(), anyBoolean());
+    }
+}


### PR DESCRIPTION
The solution to not show completed items in UI was similar to the one already implemented for rest API in com.todoapp.web.ItemsController#getItemsByList. 
A new button has been added in the UI that hides/shows completed items.
Added render tests and unit tests only for changed pieces of code matching the project style way .
I also added additional tests for rest api part to verify boolean completed param works correctly. 